### PR TITLE
fix blank cw/summary mismatch between Pleroma and Mastodon

### DIFF
--- a/fetch_posts.py
+++ b/fetch_posts.py
@@ -127,7 +127,10 @@ class PostFetcher:
 
 		obj = activity['object']
 
-		content = extract_post_content(obj['content'])
+		# Pleroma has empty string for non-cw'd posts
+		if obj['summary'] == '':
+			obj['summary'] = None
+
 		await self._db.execute(
 			"""
 			INSERT INTO posts (post_id, summary, content, published_at)


### PR DESCRIPTION
So I ran into another issue after https://github.com/ioistired/pleroma-ebooks/pull/2. 

It seems like Pleroma and Mastodon return different things for a post without a summary (i.e. without a content warning). Mastodon has NULL (None for Python) while Pleroma is an empty string (`''`). I added a conditional to check for this and Null the summaries that are empty strings.

I also removed one line of dead code because I couldn't help it :)