### PR TITLE
fix some pleroma errors with async and 500 errors

### DIFF
--- a/pleroma.py
+++ b/pleroma.py
@@ -80,10 +80,7 @@ class Pleroma:
 
 	async def status_context(self, id):
 		id = self._unpack_id(id)
-		try:
-			return await self.request('GET', f'/api/v1/statuses/{id}/context')
-		except BadResponse as exc:
-			raise exc
+		return await self.request('GET', f'/api/v1/statuses/{id}/context')
 
 	async def post(self, content, *, in_reply_to_id=None, cw=None, visibility=None):
 		if visibility not in {None, 'private', 'public', 'unlisted', 'direct'}:

--- a/reply.py
+++ b/reply.py
@@ -39,16 +39,15 @@ class ReplyBot:
 				print(f"Received HTTP 500 {retry_count} times in a row, aborting reply attempt.")
 			return
 
-		else:
-			# check if we've already been participating in this thread
-			if self.check_thread_length(context):
-				return
+		# check if we've already been participating in this thread
+		if self.check_thread_length(context):
+			return
 
-			content = self.extract_toot(notification['status']['content'])
-			if content in {'pin', 'unpin'}:
-				await self.process_command(context, notification, content)
-			else:
-				await self.reply(notification)
+		content = self.extract_toot(notification['status']['content'])
+		if content in {'pin', 'unpin'}:
+			await self.process_command(context, notification, content)
+		else:
+			await self.reply(notification)
 
 	def check_thread_length(self, context) -> bool:
 		"""return whether the thread is too long to reply to"""


### PR DESCRIPTION
Sorry for a third PR in one day haha

I was trying to get the reply functionality working and ran into some errors. First it was with some functions that appear to have been renamed, and then with a missing await.

Then I ran into an error where my Pleroma instance is randomly giving me one-off 500 errors, so I just created a new exception which I catch and try basically just re-run the request. This probably isn't the best way to do it since there could be other reasons for 500 errors that aren't resolvable by hammering the request over and over again. So, open to help on this one.