### PR TITLE
Convert military-style timestamps used by Mastodon to satisfy picky datetime.fromisoformat()

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -60,7 +60,7 @@ class _RateLimitContextManager(contextlib.AbstractAsyncContextManager):
 		if resp.headers.get('X-RateLimit-Remaining') not in {'0', '1'}:
 			return resp
 
-		await sleep_until(datetime.fromisoformat(resp.headers['X-RateLimit-Reset']))
+		await sleep_until(datetime.fromisoformat(resp.headers['X-RateLimit-Reset'].replace('Z', '+00:00')))
 		await self._request_cm.__aexit__(*(None,)*3)
 		return await self.__aenter__()
 

--- a/utils.py
+++ b/utils.py
@@ -60,6 +60,9 @@ class _RateLimitContextManager(contextlib.AbstractAsyncContextManager):
 		if resp.headers.get('X-RateLimit-Remaining') not in {'0', '1'}:
 			return resp
 
+		# We replace Z with +00:00 as datetime.fromisoformat doesn't parse
+		# military-style offsets properly. Mastodon is known to return
+		# timestamps of these kinds.
 		await sleep_until(datetime.fromisoformat(resp.headers['X-RateLimit-Reset'].replace('Z', '+00:00')))
 		await self._request_cm.__aexit__(*(None,)*3)
 		return await self.__aenter__()


### PR DESCRIPTION
Python's datetime.fromisoformat() isn't compliant with ISO 8601. The primary problem is that it refuses to parse timestamps with Z representing the UTC offset. Mastodon servers can return these timestamps. This is a really dead-simple fix that doesn't require any external dependencies that I use for Vrorgia. Using a different date package which is compliant probably a better choice, but this can act as an interim fix.